### PR TITLE
Strict doesn't allow for semantically fine changes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   ],
   "dependencies": {
     "jquery": "~1.9",
-    "ember": "~1.2",
+    "ember": "~1",
     "ember-data": "1.0.0-beta.7"
   },
   "devDependencies": {


### PR DESCRIPTION
This opens up to the use of any 1.9.Y or above (but below 2.X.Y) jquery and 1.2.Y or above (but below 2.X.Y) emberjs.

Since both these libraries maintain that they use Semantic Version Control we can assume (I believe reasonably) that minor and patch version changes won't break public APIs.

Basically I want to be able to use ember.js 1.5.
