### PR TITLE
Add missing comma to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Download the latest distribution or use bower to install
 ```js
 App.ApplicationSerializer = DS.IndexedDBSerializer.extend();
 App.ApplicationAdapter = DS.IndexedDBAdapter.extend({
-  databaseName: 'some_database_name'
+  databaseName: 'some_database_name',
   version: 1,
   migrations: function() {
     this.addModel('person');


### PR DESCRIPTION
Just a quick documentation fix; noticed the error when I did a copy+paste from the README to my editor.
