### PR TITLE
Date attributes were set to null with findAll

### DIFF
--- a/packages/indexeddb-adapter/lib/indexeddb_serializer.js
+++ b/packages/indexeddb-adapter/lib/indexeddb_serializer.js
@@ -51,11 +51,16 @@ DS.IndexedDBSerializer = DS.JSONSerializer.extend({
         var typeName = Ember.String.singularize(relation),
             embeddedPayload = payload._embedded[relation];
 
+        var embeddedType = store.modelFor(typeName);
+
         if (embeddedPayload) {
           if (Object.prototype.toString.call(embeddedPayload) === '[object Array]') {
-            store.pushMany(typeName, embeddedPayload);
+            var normalizedItems = embeddedPayload.map(
+              function (embeddedItem) { return this.normalize(embeddedType, embeddedItem); }.bind(this)
+            );
+            store.pushMany(typeName, normalizedItems);
           } else {
-            store.push(typeName, embeddedPayload);
+            store.push(typeName, this.normalize(embeddedType, embeddedPayload));
           }
         }
       }

--- a/packages/indexeddb-adapter/tests/integration/indexeddb_adapter_test.js
+++ b/packages/indexeddb-adapter/tests/integration/indexeddb_adapter_test.js
@@ -547,13 +547,14 @@ test('#find returns hasMany association', function() {
 });
 
 test('load belongsTo association when {async: false}', function() {
-  expect(2);
+  expect(3);
   stop();
   store.find('phone', 'ph1').then(function(phone) {
     var person = phone.get('person');
 
     equal(get(person, 'id'),   "p1",    "person id is correct");
     equal(get(person, 'name'), "Rambo", "person name is correct");
+    deepEqual(get(person, 'createdAt'),  new Date("2013-01-02T16:44:57.000Z"), 'date is correct');
     start();
   });
 });

--- a/packages/indexeddb-adapter/tests/unit/indexeddb_serializer_test.js
+++ b/packages/indexeddb-adapter/tests/unit/indexeddb_serializer_test.js
@@ -8,7 +8,7 @@ module('Unit/DS.IndexedDBSerializer', {
   setup: function() {
     stop();
     Ember.run(function() {
-      storeDouble = { push: function() {}, pushMany: function() {} };
+      storeDouble = { push: function() {}, pushMany: function() {}, modelFor: function () {} };
       modelDouble = { relationshipsByName: ["comments", "readers"] };
 
       subject = DS.IndexedDBSerializer.create({


### PR DESCRIPTION
With the current version of the adapter, `DS.attr('date')` attributes are set to null when the records they are part of were found using `findAll`. Turns out that this was because the serializer's `extractArray` method was normalizing each record twice.

This PR includes tests for loading date attributes in both the single record and array cases. (Single records were already working, but didn't have a test here.) There's also a small change that was necessary to get the adapter's integration tests to run at all. However, as noted in #14, there are a bunch of other failures. AFAICT, this PR does not make any of them worse.
