### PR TITLE
Use configured relationship names

### DIFF
--- a/packages/indexeddb-adapter/lib/indexeddb_serializer.js
+++ b/packages/indexeddb-adapter/lib/indexeddb_serializer.js
@@ -48,7 +48,7 @@ DS.IndexedDBSerializer = DS.JSONSerializer.extend({
   extractSingle: function(store, type, payload) {
     if (payload && payload._embedded) {
       for (var relation in payload._embedded) {
-        var typeName = Ember.String.singularize(relation),
+        var typeName = type.typeForRelationship(relation).typeKey,
             embeddedPayload = payload._embedded[relation];
 
         var embeddedType = store.modelFor(typeName);

--- a/packages/indexeddb-adapter/tests/integration/indexeddb_adapter_test.js
+++ b/packages/indexeddb-adapter/tests/integration/indexeddb_adapter_test.js
@@ -16,6 +16,7 @@ module('Integration/DS.IndexedDBAdapter', {
         name: DS.attr('string'),
         cool: DS.attr('boolean'),
         phones: DS.hasMany('phone'),
+        homeAddresses: DS.hasMany('street_address'),
         createdAt: DS.attr('date')
       });
 
@@ -24,6 +25,11 @@ module('Integration/DS.IndexedDBAdapter', {
         person: DS.belongsTo('person')
       });
 
+      App.StreetAddress = DS.Model.extend({
+        houseNumber: DS.attr('string'),
+        street: DS.attr('string'),
+        person: DS.belongsTo('person')
+      });
 
       App.ApplicationSerializer = DS.IndexedDBSerializer.extend();
 
@@ -36,6 +42,7 @@ module('Integration/DS.IndexedDBAdapter', {
             Em.run(function() {
               _this.addModel('person');
               _this.addModel('phone');
+              _this.addModel('street_address');
               resolve();
             });
           }
@@ -44,6 +51,7 @@ module('Integration/DS.IndexedDBAdapter', {
         env = setupStore({
           person: App.Person,
           phone: App.Phone,
+          street_address: App.StreetAddress,
           adapter: Adapter
         });
 
@@ -68,7 +76,7 @@ test('existence', function() {
 });
 
 test('#find should find records and then its relations', function() {
-  expect(9);
+  expect(11);
 
   stop();
   store.find('person', 'p1').then(function(person) {
@@ -89,6 +97,12 @@ test('#find should find records and then its relations', function() {
       equal(get(phone2, 'id'),     'ph2', 'second phone id is loaded correctly');
       equal(get(phone2, 'number'), '22',  'second phone number is loaded correctly');
     }
+
+    return get(phone1, 'person').get('homeAddresses');
+  }).then(function (homeAddresses) {
+    var addr1 = homeAddresses.get('firstObject');
+    equal(get(addr1, 'houseNumber'), '458', 'home address house number is loaded correctly');
+    equal(get(addr1, 'street'), 'Laplace Ave', 'home address street is loaded correctly');
 
     start();
   });

--- a/packages/indexeddb-adapter/tests/unit/indexeddb_serializer_test.js
+++ b/packages/indexeddb-adapter/tests/unit/indexeddb_serializer_test.js
@@ -9,7 +9,10 @@ module('Unit/DS.IndexedDBSerializer', {
     stop();
     Ember.run(function() {
       storeDouble = { push: function() {}, pushMany: function() {}, modelFor: function () {} };
-      modelDouble = { relationshipsByName: ["comments", "readers"] };
+      modelDouble = {
+        relationshipsByName: ["comments", "readers"],
+        typeForRelationship: function (name) { return Ember.String.singularize(name); }
+      };
 
       subject = DS.IndexedDBSerializer.create({
         normalize: function(type, payload) {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -11,7 +11,7 @@ var myDate = function(offset) {
 
 const FIXTURES = {
   "person": [
-    { id: "p1", name: "Rambo", cool: true, phones: ['ph1', 'ph2'], createdAt: "2013-01-02T16:44:57.000Z" },
+    { id: "p1", name: "Rambo", cool: true, phones: ['ph1', 'ph2'], homeAddresses: ['s1'], createdAt: "2013-01-02T16:44:57.000Z" },
     { id: "p2", name: "Braddock", cool: false, createdAt: "Fri Jan 31 2013 17:45:16 GMT-0200 (BRST)" },
     {
       id: "p3",
@@ -35,6 +35,9 @@ const FIXTURES = {
   "phone": [
     { id: "ph1", number: "11", person: "p1" },
     { id: "ph2", number: "22", person: "p1" }
+  ],
+  "street_address": [
+    { id: "s1", person: "p1", houseNumber: '458', street: 'Laplace Ave' }
   ]
 };
 


### PR DESCRIPTION
The convention for relationship names is to use the plural version of the name of the model they contain. But ember-data does not require this and neither should this adapter. E.g., as in the test that's included in this PR, you might have a `StreetAddress` model that is used for separate home and work address relationships for a person.